### PR TITLE
preloaded cards

### DIFF
--- a/Fortune-Teller/js/script.js
+++ b/Fortune-Teller/js/script.js
@@ -19,10 +19,17 @@ var textEnabled = true;
 var currCard = null;
 
 function init(){
-    /* Check when card is clicked */
+    preloadCards()
     deck.addEventListener('click', cardClickEvent);
     submitButton.addEventListener('click', submitButtonClickEvent)
 };
+
+function preloadCards() {
+    for (var i = 0; i < cardPaths.length; i++) {
+        var img = new Image();
+        img.src = cardPaths[i];
+    }
+}
 
 function cardClickEvent(event) {
     if (isCardSelected || !event.target.classList.contains('card')) {


### PR DESCRIPTION
resolve #48 

-when the page is loaded, loop through all the images and have all of them loaded into an image object. it doesn't cache or anything but i feel like this is a simple fix to our problem

REPRODUCE ISSUE:
- clear browsing data and look at the github pages (on main branch) and see that there's like a half second delay. then, clear browsing data and then look at the github pages (on preloadCards branch) and there should be no delay. 